### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["pcap", "cli", "gnuplot"]
 categories = ["command-line-utilities", "network-programming"]
 
 [dependencies]
-pcap-parser = "0"
+pcap-parser = "0.14"
 anyhow = "1"
-chrono = "0"
+chrono = "0.4"
 clap = { version = "3", features = ["cargo", "derive"] }
 humantime = "2"
 time = "0.1"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.